### PR TITLE
#120 - rdKafka consume() returns null if no message is received with librdkafka 0.11.7 or higher....

### DIFF
--- a/src/Consumers/Consumer.php
+++ b/src/Consumers/Consumer.php
@@ -322,10 +322,18 @@ class Consumer implements CanConsumeMessages
      * @throws \Junges\Kafka\Exceptions\KafkaConsumerException
      * @throws \Throwable
      */
-    private function handleMessage(Message $message): void
+    private function handleMessage(?Message $message): void
     {
+        if (null === $message) {
+            if ($this->config->shouldStopAfterLastMessage()) {
+                $this->stopConsume();
+            }
+            
+            return;
+        }
+        
         $batchConfig = $this->config->getBatchConfig();
-
+        
         if (RD_KAFKA_RESP_ERR_NO_ERROR === $message->err) {
             $this->messageCounter->add();
 


### PR DESCRIPTION
#120 - rdKafka consume() returns null if no message is received with librdkafka 0.11.7 or higher....